### PR TITLE
Compatibility with tektronixosc 0.2.0 and replacement of no longer supported QML objects

### DIFF
--- a/uniswag/devices/oscilloscopes/tektronix_osc.py
+++ b/uniswag/devices/oscilloscopes/tektronix_osc.py
@@ -7,20 +7,20 @@ from uniswag.devices.oscilloscope import Oscilloscope, OscChannel
 class TektronixOsc(Oscilloscope):
 
     TRIGGER_MODES = {
-        'Edge': 'EDGE',
-        'Pulse': 'PULSE'
+        'Edge': 'edge',
+        'Pulse': 'pulse'
     }
 
     TRIGGER_SLOPES = {
-        'Rising edge': 'RISE',
-        'Falling edge': 'FALL'
+        'Rising edge': 'rising',
+        'Falling edge': 'falling'
     }
 
     TRIGGER_SOURCES = {
-        'Channel 1': 'CH1',
-        'Channel 2': 'CH2',
-        'Line': 'LINE',
-        'Aux': 'AUX'
+        'Channel 1': 'ch1',
+        'Channel 2': 'ch2',
+        'Line': 'line',
+        'Aux': 'aux'
     }
 
     def __init__(self, name, ser_no, was_stopped_callback):
@@ -59,7 +59,7 @@ class TektronixOsc(Oscilloscope):
         # halt the oscilloscope's measurement initially
         self._is_running = False
 
-        self._osc.data_source = 'CH1'
+        self._osc.data_source = 'ch1'
 
         # start the thread that continuously retrieves new measurement data while the oscilloscope is running
         self._new_data_retrieval_thread.start()
@@ -354,8 +354,8 @@ class TektronixOsc(Oscilloscope):
 class TektronixOscChannel(OscChannel):
 
     COUPLINGS = {
-        'AC': 'AC',
-        'DC': 'DC'
+        'AC': 'ac',
+        'DC': 'dc'
     }
 
     def __init__(self, name, ch_no, mutex, ch):

--- a/uniswag/qml/res/TriggerSlider.qml
+++ b/uniswag/qml/res/TriggerSlider.qml
@@ -89,33 +89,37 @@ RowLayout{
             }
 
             // Triangle
-            ColorImage {
+            Image {
+                id: sourceImage
                 sourceSize.width: 20
                 sourceSize.height: 20
                 source: misc_path + "triangle.png"
-                color: control.pressed ? colorPalette.highlight : colorPalette.text
+                //ToDo: Find a solution to change the color of the image
+                //color: control.pressed ? colorPalette.highlight : colorPalette.text
                 visible: (triggerMode === "triangle") ? true: false
             }
 
 
             // In- or Outwindow
-            ColorImage {
+            Image {
                 anchors.bottom: rect1.top
                 anchors.horizontalCenter: rect1.horizontalCenter
                 sourceSize.width: 20
                 sourceSize.height: 20
                 source: misc_path + "triangle.png"
-                color: control.pressed ? colorPalette.highlight : colorPalette.text
+                //ToDo: Find a solution to change the color of the image
+                //color: control.pressed ? colorPalette.highlight : colorPalette.text
                 visible: (triggerMode === "out window" || triggerMode === "in window") ? true: false
                 rotation: (triggerMode === "out window")? -90: 90
             }
-            ColorImage {
+            Image {
                 anchors.top: rect1.bottom
                 anchors.horizontalCenter: rect1.horizontalCenter
                 sourceSize.width: 20
                 sourceSize.height: 20
                 source: misc_path + "triangle.png"
-                color: control.pressed ? colorPalette.highlight : colorPalette.text
+                //ToDo: Find a solution to change the color of the image
+                //color: control.pressed ? colorPalette.highlight : colorPalette.text
                 visible: (triggerMode === "out window" || triggerMode === "in window") ? true: false
                 rotation: (triggerMode === "out window")? 90: -90
             }

--- a/uniswag/qml/res/devicelist/CheckboxIndicator.qml
+++ b/uniswag/qml/res/devicelist/CheckboxIndicator.qml
@@ -22,13 +22,14 @@ Rectangle {
     border.color: darkModeEnabled? "white" : "black"
 
     // checked
-    ColorImage {
+    Image {
         id: colorImage
         x: (parent.width - width) / 2
         y: (parent.height - height) / 2
         sourceSize.width: 16
         sourceSize.height: 16
-        color: darkModeEnabled? "white" : "black"
+        //ToDo: Find a solution to change the color of the image
+        //color: darkModeEnabled? "white" : "black"
         source: misc_path + "tick.png"
         visible: false
     }

--- a/uniswag/qml/res/devicelist/Delegate.qml
+++ b/uniswag/qml/res/devicelist/Delegate.qml
@@ -82,12 +82,13 @@ ItemDelegate {
 
                 The advantage of the ColorImage is that the color of the icon can be changed (for Darkmode).
             */
-            ColorImage {
+            Image {
                 id: expandButton
                 sourceSize.width: 20
                 sourceSize.height: 20
                 source: misc_path + "right.png"
-                color: colorPalette.text
+                //ToDo: Find a solution to change the color of the image
+                //color: colorPalette.text
 
                 MouseArea {
                     anchors.fill: parent


### PR DESCRIPTION
- File tektronix_osc.py has been adapted to work with the new version 0.2.0 of tektronixosc (https://pypi.org/project/tektronixosc/)
- The "ColorImage" component has been replaced by "Image”, as "ColorImage" is no longer supported in the current QT version. This does not currently work in dark mode and still needs to be fixed.